### PR TITLE
Adding saml infront of auth config to match what om cli requires

### DIFF
--- a/opsman/types.go
+++ b/opsman/types.go
@@ -7,10 +7,10 @@ type AuthConfig struct {
 	UserName             string `yaml:"username,omitempty"`
 	Password             string `yaml:"password,omitempty"`
 	DecryptionPassphrase string `yaml:"decryption-passphrase"`
-	IDPMetadata          string `yaml:"idp-metadata,omitempty"`
-	BOSHIDPMetadata      string `yaml:"bosh-idp-metadata,omitempty"`
-	RBACAdminGroup       string `yaml:"rbac-admin-group,omitempty"`
-	RBACGroupsAttribute  string `yaml:"rbac-groups-attribute,omitempty"`
+	IDPMetadata          string `yaml:"saml-idp-metadata,omitempty"`
+	BOSHIDPMetadata      string `yaml:"saml-bosh-idp-metadata,omitempty"`
+	RBACAdminGroup       string `yaml:"saml-rbac-admin-group,omitempty"`
+	RBACGroupsAttribute  string `yaml:"saml-rbac-groups-attribute,omitempty"`
 }
 
 // EnvConfig used by the env-file command


### PR DESCRIPTION
Adding same infront of the attributes created for saml.

om requires that the attributes to be exactly what they are in the command line:
```
--config, -c                  string             path to yml file for configuration (keys must match the following command line flags)
```
And the flags are:
```
saml-bosh-idp-metadata
saml-idp-metadata
saml-rbac-admin-group
saml-rbac-groups-attribute
```

Currently when running from the pipeline I see:
```
 om --env env/env.yml configure-saml-authentication --config config/auth.yml
could not execute "configure-saml-authentication": could not parse configure-saml-authentication flags: flag provided but not defined: -idp-metadata
```